### PR TITLE
Fix Connection String for LocalDB

### DIFF
--- a/src/code-listings/lesson-35/Core/Scratchpad.fsx
+++ b/src/code-listings/lesson-35/Core/Scratchpad.fsx
@@ -1,6 +1,7 @@
 #load "Domain.fs"
 #load "Operations.fs"
 #r @"..\packages\FSharp.Data.SqlClient.1.8.2\lib\net40\FSharp.Data.SqlClient.dll"
+#r "System.Configuration.dll"
 #load "SqlRepository.fs"
 
 open Capstone6.Operations

--- a/src/code-listings/lesson-35/Core/SqlRepository.fs
+++ b/src/code-listings/lesson-35/Core/SqlRepository.fs
@@ -1,4 +1,4 @@
-﻿module internal Capstone6.SqlRepository
+module internal Capstone6.SqlRepository
 
 open Capstone6.Domain
 open FSharp.Data
@@ -6,7 +6,7 @@ open System
 
 [<AutoOpen>]
 module private DB =
-    let [<Literal>] Conn = "Name=AccountsDb"
+    let [<Literal>] Conn = @"Data Source=(localdb)\MSSQLLocalDB;Database=BankAccountDb;Integrated Security=True;Connect Timeout=60"
     type AccountsDb = SqlProgrammabilityProvider<Conn>
     type GetAccountId = SqlCommandProvider<"SELECT TOP 1 AccountId FROM dbo.Account WHERE Owner = @owner", Conn, SingleRow = true>
     type FindTransactions = SqlCommandProvider<"SELECT Timestamp, OperationId, Amount FROM dbo.AccountTransaction WHERE AccountId = @accountId", Conn>


### PR DESCRIPTION
The given connection string result in an System.ArgumentException key 'name' not supported. Using the connection string from `Scratchpad.fsx` works