### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,10 @@
 
 This repository contains all F# code listings as required for all exercises and samples within the 'Get Programming with F#' book, available [here]( https://www.manning.com/books/get-programming-with-f-sharp).
 
-To install all dependencies as needed for the exercises, simply run the build.cmd file, which uses Paket to download all NuGet dependencies.
+To install all dependencies as needed for the exercises, in the repo root simply run:
+
+```dotnet new tool-manifest
+dotnet tool install paket
+dotnet paket restore
+```
+ which uses Paket to download all NuGet dependencies.


### PR DESCRIPTION
in netcore branch for VS2019 .NET Core 3 environments

Installed paket as a local dotnet tool. As installing and invoking the paket bootstrapper through build.cmd contained errors.

I first encountered build issues in lesson 8. The capstone where scripts were collated into a built application.