### PR TITLE
add filter to lesson-24/Operations.fs

### DIFF
--- a/src/code-listings/lesson-24/Auditing.fs
+++ b/src/code-listings/lesson-24/Auditing.fs
@@ -14,4 +14,4 @@ let composedLogger =
           printTransaction ]
     fun accountId owner transaction ->
         loggers
-        |> List.iter(fun logger -> logger accountId owner transaction)
+        |> List.iter(fun logger -> logger owner accountId transaction) // logger func signature shall be consistent: owner accountId transaction

--- a/src/code-listings/lesson-24/Operations.fs
+++ b/src/code-listings/lesson-24/Operations.fs
@@ -31,6 +31,7 @@ let loadAccount (owner, accountId, transactions) =
     let openingAccount = { AccountId = accountId; Balance = 0M; Owner = { Name = owner } }
 
     transactions
+    |> Seq.filter(fun txn -> txn.Accepted = true) // filter out not accepted transactions
     |> Seq.sortBy(fun txn -> txn.Timestamp)
     |> Seq.fold(fun account txn ->
         if txn.Operation = "withdraw" then account |> withdraw txn.Amount


### PR DESCRIPTION
In ```loadAccount``` func, the transactions shall be filter out those not accepted transactions before folded to account.

It is just my opinion. Hope it help a bit.
The book is great. Thank you.